### PR TITLE
Fast queries

### DIFF
--- a/api/db_queries.py
+++ b/api/db_queries.py
@@ -111,23 +111,32 @@ RETURN (
 """
 
 query_graph_data = """
-LET parids = SORTED_UNIQUE(FLATTEN(
-    FOR file IN files
-        FILTER file._key == @filename
-        FOR segmentnr IN file.segmentnrs
-            FOR segment IN segments
-            FILTER segment._key == segmentnr
-            RETURN segment.parallel_ids
-))
+FOR p IN parallels
+    FILTER p.root_filename == @filename
+    LIMIT 15000
+    FILTER p.score >= @score
+    FILTER p.par_length >= @parlength
+    FILTER p["co-occ"] <= @coocc
+    RETURN { "textname": SPLIT(p.par_segnr[0],":")[0], "parlength": p.par_length}
+"""
 
-FOR segment_id IN parids
-    FOR p IN parallels
-        FILTER p._key == segment_id
+query_total_numbers = """
+FOR p IN parallels
+    FILTER p.root_filename == @filename
+    LIMIT 15000
+    LET filtertest = (
+        FOR item IN @limitcollection
+            RETURN REGEX_TEST(p.par_segnr[0], item)
+        )
+        LET filternr = (@limitcollection != []) ? POSITION(filtertest, true) : true
+        FILTER filternr == true
         FILTER p.score >= @score
         FILTER p.par_length >= @parlength
         FILTER p["co-occ"] <= @coocc
-        RETURN { "textname": SPLIT(p.par_segnr[0],":")[0], "parlength": p.par_length }
+        COLLECT WITH COUNT INTO length
+RETURN length
 """
+
 
 query_categories_per_collection = """
 RETURN MERGE(

--- a/api/db_queries.py
+++ b/api/db_queries.py
@@ -62,6 +62,8 @@ LET file_parallels = (
                     par_segnr: p.par_segnr, 
                     par_offset_beg: p.par_offset_beg, 
                     par_offset_end: p.par_offset_end, 
+                    root_offset_beg: p.root_offset_beg, 
+                    root_offset_end: p.root_offset_end-1, 
                     par_segment: p.par_segtext, 
                     file_name: p.id, 
                     root_lang: segment.lang,

--- a/api/main.py
+++ b/api/main.py
@@ -503,14 +503,12 @@ async def get_all_collections():
 
 @app.get("/parallels/{file_name}/count")
 async def get_counts_for_file(
-        response: Response,
         file_name: str,
         score: int = 0,
         par_length: int = 0,
         co_occ: int = 0,
         limit_collection: List[str] = Query([]),
-):
-    
+):    
     try:
         language = get_language_from_filename(file_name)
         db = get_db()

--- a/api/main.py
+++ b/api/main.py
@@ -18,6 +18,7 @@ from .db_queries import (
     query_parallels_for_left_text,
     query_graph_data,
     query_all_collections,
+    query_total_numbers,
     query_sorted_category_list,
     query_categories_per_collection
 )
@@ -471,4 +472,40 @@ async def get_all_collections():
         print("KeyError: ", e)
         raise HTTPException(status_code=400)
 
-        
+
+@app.get("/parallels/{file_name}/count")
+async def get_counts_for_file(
+        response: Response,
+        file_name: str,
+        score: int = 0,
+        par_length: int = 0,
+        co_occ: int = 0,
+        limit_collection: List[str] = Query([]),
+):
+    
+    try:
+        language = get_language_from_filename(file_name)
+        db = get_db()
+        query_graph_result = db.AQLQuery(
+            query=query_total_numbers,
+            batchSize=100000,
+            bindVars={
+                "filename": file_name,
+                "score": score,
+                "parlength": par_length,
+                "coocc": co_occ,
+                "limitcollection": limit_collection,
+            },
+        )
+        return {
+            "parallel_count": query_graph_result.result,
+        }
+    except DocumentNotFoundError as e:
+        print(e)
+        raise HTTPException(status_code=404, detail="Item not found")
+    except AQLQueryError as e:
+        print("AQLQueryError: ", e)
+        raise HTTPException(status_code=400, detail=e.errors)
+    except KeyError as e:
+        print("KeyError: ", e)
+        raise HTTPException(status_code=400)

--- a/dataloader/loader.py
+++ b/dataloader/loader.py
@@ -60,7 +60,7 @@ def load_segments_and_parallels_data_from_menu_file(
         print(f"{file_url} is not a gzip file. Ignoring.")
         return
 
-    [segments, parallels] = get_segments_and_parallels_from_gzipped_local_file(
+    [segments, parallels] = get_segments_and_parallels_from_gzipped_remote_file(
         file_url
     )
 

--- a/dataloader/utils.py
+++ b/dataloader/utils.py
@@ -55,11 +55,11 @@ def should_download_file(file_lang: str, file_name: str) -> bool:
     Limit source file set size to speed up loading process
     Can be controlled with the `LIMIT` environment variable.
     """
-    if file_lang == LANG_PALI and file_name.startswith("mn"):
-        return True
-    elif file_lang == LANG_CHINESE and file_name.startswith("T31_T0004"):
-        return True
-    elif file_lang == LANG_TIBETAN and file_name.startswith("T06TD4021E"):
+    # if file_lang == LANG_PALI and file_name.startswith("mn"):
+    #     return True
+    # elif file_lang == LANG_CHINESE and file_name.startswith("T31_T0004"):
+    #     return True
+    if file_lang == LANG_TIBETAN and file_name.startswith("T06"):
         return True
     else:
         return False

--- a/dataloader/utils.py
+++ b/dataloader/utils.py
@@ -55,10 +55,10 @@ def should_download_file(file_lang: str, file_name: str) -> bool:
     Limit source file set size to speed up loading process
     Can be controlled with the `LIMIT` environment variable.
     """
-    # if file_lang == LANG_PALI and file_name.startswith("mn"):
-    #     return True
-    # elif file_lang == LANG_CHINESE and file_name.startswith("T31_T0004"):
-    #     return True
+    if file_lang == LANG_PALI and file_name.startswith("mn"):
+        return True
+    elif file_lang == LANG_CHINESE and file_name.startswith("T31_T0004"):
+        return True
     if file_lang == LANG_TIBETAN and file_name.startswith("T06"):
         return True
     else:


### PR DESCRIPTION
These changes require the rebuilding of the database for two reasons:
1) parallels are randomized before inserted into the DB 
2) the root_filename field is added to each parallel for the lookup. 