### PR TITLE
removing small errors from search

### DIFF
--- a/api/cache_config.py
+++ b/api/cache_config.py
@@ -36,7 +36,7 @@ class CustomJsonCoder(JsonCoder):
         logger.info("Starting decode of value type: %s", type(value))
         try:
             if isinstance(value, bytes):
-                decoded_str = value.decode('utf-8')
+                decoded_str = value.decode("utf-8")
             elif isinstance(value, str):
                 decoded_str = value
             else:
@@ -63,7 +63,7 @@ class CustomJsonCoder(JsonCoder):
             if isinstance(value, MenudataOutput):
                 value = value.dict()
             json_str = json.dumps(value)
-            return json_str.encode('utf-8')
+            return json_str.encode("utf-8")
         except Exception as e:
             logger.error("Encode error: %s", str(e), exc_info=True)
             raise
@@ -71,6 +71,7 @@ class CustomJsonCoder(JsonCoder):
 
 def make_cache_key_builder():
     """Creates a function that builds consistent cache keys for Redis storage."""
+
     def cache_key_builder(
         func,
         namespace: str = "",
@@ -113,10 +114,11 @@ def make_cache_key_builder():
 def cached_endpoint(expire: int = CACHE_TIMES["MEDIUM"]):
     """
     Decorator that implements Redis-based caching for API endpoints.
-    
+
     Args:
         expire: Cache expiration time in seconds
     """
+
     def wrapper(func):
         @wraps(func)
         async def debug_wrapper(*args, **kwargs):
@@ -136,7 +138,7 @@ def cached_endpoint(expire: int = CACHE_TIMES["MEDIUM"]):
                     cached_value = await redis.get(cache_key)
                     logger.info(
                         "Retrieved cached value of length: %s",
-                        len(cached_value) if cached_value else 0
+                        len(cached_value) if cached_value else 0,
                     )
 
                     if cached_value:
@@ -144,7 +146,7 @@ def cached_endpoint(expire: int = CACHE_TIMES["MEDIUM"]):
                             decoded = CustomJsonCoder.decode(cached_value)
                             logger.info(
                                 "Successfully decoded cached value of type: %s",
-                                type(decoded)
+                                type(decoded),
                             )
                             return decoded
                         except ValueError as e:

--- a/api/main.py
+++ b/api/main.py
@@ -35,6 +35,7 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
     """
     Middleware to control cache headers for GET requests.
     """
+
     async def dispatch(self, request, call_next):
         response = await call_next(request)
         if request.method == "GET":
@@ -92,8 +93,6 @@ APP.include_router(numbers_view.router, prefix="/numbers-view")
 APP.include_router(links.router, prefix="/links")
 APP.include_router(utils.router, prefix="/utils")
 APP.include_router(menu.router)
-
-
 
 
 @APP.get("/")

--- a/api/queries/search_queries.py
+++ b/api/queries/search_queries.py
@@ -3,14 +3,14 @@ LET chinese_results = (
     FOR d IN search_index_zh_view
         SEARCH PHRASE(d.original, @search_string_zh, 'text_zh')
         LIMIT 1000
-        FILTER LENGTH(@filter_include_files) == 0 OR d.par_filename IN @filter_include_files
-        FILTER LENGTH(@filter_exclude_files) == 0 OR d.par_filename NOT IN @filter_exclude_files
+        FILTER LENGTH(@filter_include_files) == 0 OR d.filename IN @filter_include_files
+        FILTER LENGTH(@filter_exclude_files) == 0 OR d.filename NOT IN @filter_exclude_files
 
-        FILTER LENGTH(@filter_include_categories) == 0 OR d.par_category IN @filter_include_categories
-        FILTER LENGTH(@filter_exclude_categories) == 0 OR d.par_category NOT IN @filter_exclude_categories
+        FILTER LENGTH(@filter_include_categories) == 0 OR d.category IN @filter_include_categories
+        FILTER LENGTH(@filter_exclude_categories) == 0 OR d.category NOT IN @filter_exclude_categories
 
-        FILTER LENGTH(@filter_include_collections) == 0 OR d.par_collection IN @filter_include_collections
-        FILTER LENGTH(@filter_exclude_collections) == 0 OR d.par_collection NOT IN @filter_exclude_collections
+        FILTER LENGTH(@filter_include_collections) == 0 OR d.collection IN @filter_include_collections
+        FILTER LENGTH(@filter_exclude_collections) == 0 OR d.collection NOT IN @filter_exclude_collections
         RETURN d
     )
 
@@ -18,42 +18,42 @@ let tibetan_fuzzy_results = (
     FOR d IN search_index_bo_view
         SEARCH PHRASE(d.analyzed, @search_string_bo, 'tibetan_fuzzy_analyzer')
         LIMIT 1000
-        FILTER LENGTH(@filter_include_files) == 0 OR d.par_filename IN @filter_include_files
-        FILTER LENGTH(@filter_exclude_files) == 0 OR d.par_filename NOT IN @filter_exclude_files
+        FILTER LENGTH(@filter_include_files) == 0 OR d.filename IN @filter_include_files
+        FILTER LENGTH(@filter_exclude_files) == 0 OR d.filename NOT IN @filter_exclude_files
 
-        FILTER LENGTH(@filter_include_categories) == 0 OR d.par_category IN @filter_include_categories
-        FILTER LENGTH(@filter_exclude_categories) == 0 OR d.par_category NOT IN @filter_exclude_categories
+        FILTER LENGTH(@filter_include_categories) == 0 OR d.category IN @filter_include_categories
+        FILTER LENGTH(@filter_exclude_categories) == 0 OR d.category NOT IN @filter_exclude_categories
 
-        FILTER LENGTH(@filter_include_collections) == 0 OR d.par_collection IN @filter_include_collections
-        FILTER LENGTH(@filter_exclude_collections) == 0 OR d.par_collection NOT IN @filter_exclude_collections
+        FILTER LENGTH(@filter_include_collections) == 0 OR d.collection IN @filter_include_collections
+        FILTER LENGTH(@filter_exclude_collections) == 0 OR d.collection NOT IN @filter_exclude_collections
         RETURN d
     )
 let sanskrit_results = (
     FOR d IN search_index_sa_view
         SEARCH PHRASE(d.analyzed, @search_string_sa, 'sanskrit_analyzer')
         LIMIT 1000
-        FILTER LENGTH(@filter_include_files) == 0 OR d.par_filename IN @filter_include_files
-        FILTER LENGTH(@filter_exclude_files) == 0 OR d.par_filename NOT IN @filter_exclude_files
+        FILTER LENGTH(@filter_include_files) == 0 OR d.filename IN @filter_include_files
+        FILTER LENGTH(@filter_exclude_files) == 0 OR d.filename NOT IN @filter_exclude_files
 
-        FILTER LENGTH(@filter_include_categories) == 0 OR d.par_category IN @filter_include_categories
-        FILTER LENGTH(@filter_exclude_categories) == 0 OR d.par_category NOT IN @filter_exclude_categories
+        FILTER LENGTH(@filter_include_categories) == 0 OR d.category IN @filter_include_categories
+        FILTER LENGTH(@filter_exclude_categories) == 0 OR d.category NOT IN @filter_exclude_categories
 
-        FILTER LENGTH(@filter_include_collections) == 0 OR d.par_collection IN @filter_include_collections
-        FILTER LENGTH(@filter_exclude_collections) == 0 OR d.par_collection NOT IN @filter_exclude_collections
+        FILTER LENGTH(@filter_include_collections) == 0 OR d.collection IN @filter_include_collections
+        FILTER LENGTH(@filter_exclude_collections) == 0 OR d.collection NOT IN @filter_exclude_collections
         RETURN d
     )
 let sanskrit_results_fuzzy = (
     FOR d IN search_index_sa_view
         SEARCH PHRASE(d.analyzed, @search_string_sa_fuzzy, 'sanskrit_analyzer')
         LIMIT 1000
-        FILTER LENGTH(@filter_include_files) == 0 OR d.par_filename IN @filter_include_files
-        FILTER LENGTH(@filter_exclude_files) == 0 OR d.par_filename NOT IN @filter_exclude_files
+        FILTER LENGTH(@filter_include_files) == 0 OR d.filename IN @filter_include_files
+        FILTER LENGTH(@filter_exclude_files) == 0 OR d.filename NOT IN @filter_exclude_files
 
-        FILTER LENGTH(@filter_include_categories) == 0 OR d.par_category IN @filter_include_categories
-        FILTER LENGTH(@filter_exclude_categories) == 0 OR d.par_category NOT IN @filter_exclude_categories
+        FILTER LENGTH(@filter_include_categories) == 0 OR d.category IN @filter_include_categories
+        FILTER LENGTH(@filter_exclude_categories) == 0 OR d.category NOT IN @filter_exclude_categories
 
-        FILTER LENGTH(@filter_include_collections) == 0 OR d.par_collection IN @filter_include_collections
-        FILTER LENGTH(@filter_exclude_collections) == 0 OR d.par_collection NOT IN @filter_exclude_collections
+        FILTER LENGTH(@filter_include_collections) == 0 OR d.collection IN @filter_include_collections
+        FILTER LENGTH(@filter_exclude_collections) == 0 OR d.collection NOT IN @filter_exclude_collections
         RETURN d
     )
 
@@ -61,14 +61,14 @@ let pali_results = (
     FOR d IN search_index_pa_view
         SEARCH PHRASE(d.analyzed, @search_string_pa, 'pali_analyzer')
         LIMIT 1000
-        FILTER LENGTH(@filter_include_files) == 0 OR d.par_filename IN @filter_include_files
-        FILTER LENGTH(@filter_exclude_files) == 0 OR d.par_filename NOT IN @filter_exclude_files
+        FILTER LENGTH(@filter_include_files) == 0 OR d.filename IN @filter_include_files
+        FILTER LENGTH(@filter_exclude_files) == 0 OR d.filename NOT IN @filter_exclude_files
 
-        FILTER LENGTH(@filter_include_categories) == 0 OR d.par_category IN @filter_include_categories
-        FILTER LENGTH(@filter_exclude_categories) == 0 OR d.par_category NOT IN @filter_exclude_categories
+        FILTER LENGTH(@filter_include_categories) == 0 OR d.category IN @filter_include_categories
+        FILTER LENGTH(@filter_exclude_categories) == 0 OR d.category NOT IN @filter_exclude_categories
 
-        FILTER LENGTH(@filter_include_collections) == 0 OR d.par_collection IN @filter_include_collections
-        FILTER LENGTH(@filter_exclude_collections) == 0 OR d.par_collection NOT IN @filter_exclude_collections
+        FILTER LENGTH(@filter_include_collections) == 0 OR d.collection IN @filter_include_collections
+        FILTER LENGTH(@filter_exclude_collections) == 0 OR d.collection NOT IN @filter_exclude_collections
         RETURN d
     )
 LET results = FLATTEN([chinese_results, tibetan_fuzzy_results,sanskrit_results,sanskrit_results_fuzzy,pali_results])
@@ -93,7 +93,7 @@ LET results_with_names = (
         segment_nr: r.segment_nr,
         full_names: full_names[0]
     }
-)    
+)
 
 RETURN results_with_names
 

--- a/api/search/search_utils.py
+++ b/api/search/search_utils.py
@@ -20,7 +20,7 @@ def preprocess_search_string(search_string, language):
 
     # test if string contains Tibetan characters
     search_string = search_string.strip()
-    search_string.replace("ṁ", "ṃ")
+    search_string = search_string.replace("ṁ", "ṃ")
     search_string = re.sub(
         "@[0-9a-b+]+", "", search_string
     )  # remove possible bo folio numbers

--- a/api/search/search_utils.py
+++ b/api/search/search_utils.py
@@ -20,6 +20,7 @@ def preprocess_search_string(search_string, language):
 
     # test if string contains Tibetan characters
     search_string = search_string.strip()
+    search_string.replace("ṁ", "ṃ")
     search_string = re.sub(
         "@[0-9a-b+]+", "", search_string
     )  # remove possible bo folio numbers
@@ -57,11 +58,11 @@ def preprocess_search_string(search_string, language):
     if language == "sa":
         bo = zh = pa = ""
     elif language == "bo":
-        zh = pa = ""
+        zh = pa = sa = ""
     elif language == "zh":
-        bo = pa = ""
+        bo = pa = sa = ""
     elif language == "pa":
-        bo = zh = ""
+        bo = zh = sa = ""
     return {"sa": sa, "sa_fuzzy": sa_fuzzy, "bo": bo, "pa": pa, "zh": zh}
 
 


### PR DESCRIPTION
Removing a few errors from the search API:

- it didn't like m with dot on top
- when pali was selected it took sanskrit as well
- it was searching for a value in the search index that didn't exist for the filters because I suspect it was copied from another AQL query and not properly adapted.

(other files changed are just black changes)

What still doesn't work is that the collection filter cannot find a collection because it doesn't exist in the search index. That is a dataloader problem and I'll make an issue for that.