### PR TITLE
Text view add match id handling

### DIFF
--- a/api/colormaps.py
+++ b/api/colormaps.py
@@ -33,7 +33,9 @@ def create_segmented_text(text, colormap, matchmap, active_map):
             current_segment = ""
 
         current_segment += char
-        last_matches, last_color, last_active_match = current_matches, current_color, current_active_match
+        last_matches = current_matches
+        last_color = current_color
+        last_active_match = current_active_match
     # Add the last segment
     result_segments.append(
         {
@@ -86,7 +88,7 @@ def calculate_color_maps_text_view(data, active_match=None):
         segtext_len = len(entry["segtext"])
         current_colormap = [0] * segtext_len
         current_active_map = [False] * segtext_len
-        current_matchmap = [[] for _ in range(segtext_len)]        
+        current_matchmap = [[] for _ in range(segtext_len)]
         # this variable holds the ids of the parallels that are present at each character
         # now add the color layer
         for parallel_id in entry["parallel_ids"]:
@@ -107,9 +109,10 @@ def calculate_color_maps_text_view(data, active_match=None):
                 current_colormap[item] += 1
                 if parallel_id not in current_matchmap[item]:
                     current_matchmap[item].append(parallel_id)
-        # when an active match is present, we need to highlight the corresponding segment since we cannot be 100% sure that the right match is present in the database.
-        if active_match: 
-            start = 0 
+        # when an active match is present, we need to highlight the corresponding segment, 
+        # since we cannot be 100% sure that the right match is present in the database.
+        if active_match:
+            start = 0
             end = segtext_len
             if active_match["par_segnr"][0] == entry["segnr"]:
                 start = active_match["par_offset_beg"]

--- a/api/colormaps.py
+++ b/api/colormaps.py
@@ -5,7 +5,7 @@ This file holds the functions for creating the colormaps.
 from .utils import shorten_segment_names, prettify_score
 
 
-def create_segmented_text(text, colormap, matchmap):
+def create_segmented_text(text, colormap, matchmap, active_map):
     """Create segmented text based on the given colormap and matchmap."""
 
     def filter_and_sort(matches):
@@ -16,24 +16,32 @@ def create_segmented_text(text, colormap, matchmap):
     current_segment = ""
     last_matches = filter_and_sort(matchmap[0])
     last_color = colormap[0]
+    last_active_match = active_map[0]
     for i, char in enumerate(text):
         current_color = colormap[i]
         current_matches = filter_and_sort(matchmap[i])
+        current_active_match = active_map[i]
         if current_matches != last_matches:
             result_segments.append(
                 {
                     "text": current_segment,
                     "highlightColor": last_color,
                     "matches": last_matches,
+                    "is_active_match": last_active_match,
                 }
             )
             current_segment = ""
 
         current_segment += char
-        last_matches, last_color = current_matches, current_color
+        last_matches, last_color, last_active_match = current_matches, current_color, current_active_match
     # Add the last segment
     result_segments.append(
-        {"text": current_segment, "highlightColor": last_color, "matches": last_matches}
+        {
+            "text": current_segment,
+            "highlightColor": last_color,
+            "matches": last_matches,
+            "is_active_match": last_active_match,
+        }
     )
     return result_segments
 
@@ -47,13 +55,13 @@ def create_segmented_text_color_only(text, colormap):
         current_color = colormap[i]
         if current_color != last_color:
             result_segments.append(
-                {"text": abbreviate(current_segment), "highlightColor": last_color}
+                {"text": current_segment, "highlightColor": last_color}
             )
             current_segment = ""
         current_segment += text[i]
         last_color = current_color
     result_segments.append(
-        {"text": abbreviate(current_segment), "highlightColor": last_color}
+        {"text": current_segment, "highlightColor": last_color}
     )
     return result_segments
 
@@ -68,17 +76,17 @@ def abbreviate(text):
     return newtext
 
 
-def calculate_color_maps_text_view(data):
+def calculate_color_maps_text_view(data, active_match=None):
     """calculates the color maps for the text view"""
     textleft = data["textleft"]
     parallels_dict = dict(zip(data["parallel_ids"], data["parallels"]))
+    active_flag = False
     for entry in textleft:
         # initialize with zeros
         segtext_len = len(entry["segtext"])
-        current_colormap = [
-            0
-        ] * segtext_len  # this variable holds the ints for the colors of each character
-        current_matchmap = [[] for _ in range(segtext_len)]
+        current_colormap = [0] * segtext_len
+        current_active_map = [False] * segtext_len
+        current_matchmap = [[] for _ in range(segtext_len)]        
         # this variable holds the ids of the parallels that are present at each character
         # now add the color layer
         for parallel_id in entry["parallel_ids"]:
@@ -99,8 +107,24 @@ def calculate_color_maps_text_view(data):
                 current_colormap[item] += 1
                 if parallel_id not in current_matchmap[item]:
                     current_matchmap[item].append(parallel_id)
+        # when an active match is present, we need to highlight the corresponding segment since we cannot be 100% sure that the right match is present in the database.
+        if active_match: 
+            start = 0 
+            end = segtext_len
+            if active_match["par_segnr"][0] == entry["segnr"]:
+                start = active_match["par_offset_beg"]
+                active_flag = True
+            if active_match["par_segnr"][-1] == entry["segnr"]:
+                end = active_match["par_offset_end"]
+            end = min(end, segtext_len)
+            if active_flag:
+                for item in range(start, end):
+                    current_colormap[item] += 1
+                    current_active_map[item] = True
+                if active_match["par_segnr"][-1] == entry["segnr"]:
+                    active_flag = False
         entry["segtext"] = create_segmented_text(
-            entry["segtext"], current_colormap, current_matchmap
+            entry["segtext"], current_colormap, current_matchmap, current_active_map
         )
 
     for entry in textleft:

--- a/api/colormaps.py
+++ b/api/colormaps.py
@@ -78,54 +78,71 @@ def abbreviate(text):
     return newtext
 
 
+def _process_parallel_segment(entry, parallels_dict, parallel_id, segtext_len, current_colormap, current_matchmap):
+    """Helper function to process a single parallel segment"""
+    current_parallel = parallels_dict.get(parallel_id)
+    if current_parallel is None:
+        return
+
+    start = 0
+    end = segtext_len
+    if current_parallel["root_segnr"][0] == entry["segnr"]:
+        start = current_parallel["root_offset_beg"]
+    if current_parallel["root_segnr"][-1] == entry["segnr"]:
+        end = current_parallel["root_offset_end"]
+    
+    end = min(end, segtext_len)
+    for item in range(start, end):
+        current_colormap[item] += 1
+        if parallel_id not in current_matchmap[item]:
+            current_matchmap[item].append(parallel_id)
+
+def _process_active_match(entry, active_match, segtext_len, current_colormap, current_active_map):
+    """Helper function to process the active match"""
+    active_flag = False
+    if not active_match:
+        return active_flag
+
+    start = 0
+    end = segtext_len
+    if active_match["par_segnr"][0] == entry["segnr"]:
+        start = active_match["par_offset_beg"]
+        active_flag = True
+    if active_match["par_segnr"][-1] == entry["segnr"]:
+        end = active_match["par_offset_end"]
+    
+    end = min(end, segtext_len)
+    if active_flag:
+        for item in range(start, end):
+            current_colormap[item] += 1
+            current_active_map[item] = True
+    
+    return active_flag and active_match["par_segnr"][-1] == entry["segnr"]
+
 def calculate_color_maps_text_view(data, active_match=None):
     """calculates the color maps for the text view"""
     textleft = data["textleft"]
     parallels_dict = dict(zip(data["parallel_ids"], data["parallels"]))
     active_flag = False
+
     for entry in textleft:
-        # initialize with zeros
         segtext_len = len(entry["segtext"])
         current_colormap = [0] * segtext_len
         current_active_map = [False] * segtext_len
         current_matchmap = [[] for _ in range(segtext_len)]
-        # this variable holds the ids of the parallels that are present at each character
-        # now add the color layer
-        for parallel_id in entry["parallel_ids"]:
-            current_parallel = parallels_dict.get(parallel_id)
-            if current_parallel is None:
-                continue
 
-            start = 0
-            end = segtext_len
-            if current_parallel["root_segnr"][0] == entry["segnr"]:
-                start = current_parallel["root_offset_beg"]
-            if current_parallel["root_segnr"][-1] == entry["segnr"]:
-                end = current_parallel["root_offset_end"]
-            # it is embarassing that we need to do this,
-            # this should be dealt with at data-loader level
-            end = min(end, segtext_len)
-            for item in range(start, end):
-                current_colormap[item] += 1
-                if parallel_id not in current_matchmap[item]:
-                    current_matchmap[item].append(parallel_id)
-        # when an active match is present, we need to highlight the corresponding segment, 
-        # since we cannot be 100% sure that the right match is present in the database.
-        if active_match:
-            start = 0
-            end = segtext_len
-            if active_match["par_segnr"][0] == entry["segnr"]:
-                start = active_match["par_offset_beg"]
-                active_flag = True
-            if active_match["par_segnr"][-1] == entry["segnr"]:
-                end = active_match["par_offset_end"]
-            end = min(end, segtext_len)
-            if active_flag:
-                for item in range(start, end):
-                    current_colormap[item] += 1
-                    current_active_map[item] = True
-                if active_match["par_segnr"][-1] == entry["segnr"]:
-                    active_flag = False
+        for parallel_id in entry["parallel_ids"]:
+            _process_parallel_segment(
+                entry, parallels_dict, parallel_id, segtext_len,
+                current_colormap, current_matchmap
+            )
+
+        if active_match and (active_flag or active_match["par_segnr"][0] == entry["segnr"]):
+            active_flag = not _process_active_match(
+                entry, active_match, segtext_len,
+                current_colormap, current_active_map
+            )
+
         entry["segtext"] = create_segmented_text(
             entry["segtext"], current_colormap, current_matchmap, current_active_map
         )

--- a/api/colormaps.py
+++ b/api/colormaps.py
@@ -62,9 +62,7 @@ def create_segmented_text_color_only(text, colormap):
             current_segment = ""
         current_segment += text[i]
         last_color = current_color
-    result_segments.append(
-        {"text": current_segment, "highlightColor": last_color}
-    )
+    result_segments.append({"text": current_segment, "highlightColor": last_color})
     return result_segments
 
 

--- a/api/endpoints/models/text_view_models.py
+++ b/api/endpoints/models/text_view_models.py
@@ -12,7 +12,7 @@ class TextParallelsInput(BaseModel):
     page: int = 0
 
 
-class FullMatchText(FullText):    
+class FullMatchText(FullText):
     matches: List[str]
     is_active_match: bool = False
 

--- a/api/endpoints/models/text_view_models.py
+++ b/api/endpoints/models/text_view_models.py
@@ -8,11 +8,13 @@ class TextParallelsInput(BaseModel):
     folio: str = ""
     active_segment: Optional[str] = "none"
     filters: Optional[Filters]
+    active_match_id: Optional[str] = None
     page: int = 0
 
 
-class FullMatchText(FullText):
+class FullMatchText(FullText):    
     matches: List[str]
+    is_active_match: bool = False
 
 
 class TextItem(BaseModel):

--- a/api/endpoints/search.py
+++ b/api/endpoints/search.py
@@ -51,9 +51,13 @@ async def search(search_input: SearchInput):
             search_strings["sa_fuzzy"] if "sa_fuzzy" in search_strings else None
         ),
         "search_string_bo": search_strings["bo"] if "bo" in search_strings else None,
-        "search_string_bo_fuzzy": search_strings["bo_fuzzy"] if "bo_fuzzy" in search_strings else None,
+        "search_string_bo_fuzzy": (
+            search_strings["bo_fuzzy"] if "bo_fuzzy" in search_strings else None
+        ),
         "search_string_pa": search_strings["pa"] if "pa" in search_strings else None,
-        "search_string_pa_fuzzy": search_strings["pa_fuzzy"] if "pa_fuzzy" in search_strings else None,
+        "search_string_pa_fuzzy": (
+            search_strings["pa_fuzzy"] if "pa_fuzzy" in search_strings else None
+        ),
         "search_string_zh": search_strings["zh"] if "zh" in search_strings else None,
     }
 

--- a/api/endpoints/text_view.py
+++ b/api/endpoints/text_view.py
@@ -42,13 +42,13 @@ async def get_file_text_segments_and_parallels(input: TextParallelsInput) -> Any
     # active_segment is used to scroll to and highlight the segment in the text view
     if input.active_segment != "none":
         page = get_page_for_segment(input.active_segment)
-        filename = get_filename_from_segmentnr(input.active_segment)    
+        filename = get_filename_from_segmentnr(input.active_segment)
     # active_match_id bypasses page, filename and active_segement in order to highlight the active match in the text view
     if input.active_match_id:
         query_result = execute_query(
             text_view_queries.QUERY_GET_MATCH_BY_ID,
             bind_vars={"active_match_id": input.active_match_id},
-        )        
+        )
         active_match = query_result.result[0]
         page = get_page_for_segment(active_match["par_segnr"][0])
         filename = get_filename_from_segmentnr(active_match["par_segnr"][0])

--- a/api/queries/search_query_builder.py
+++ b/api/queries/search_query_builder.py
@@ -56,7 +56,7 @@ def build_query_search(query_languages, bind_variables, filters=None, max_limit=
                 "phrase_field": "d.analyzed",
                 "analyzer": "tibetan_fuzzy_analyzer",
                 "bind_var": "@search_string_bo_fuzzy",
-            }
+            },
         ],
         "pa": [
             # normal Pali
@@ -72,7 +72,7 @@ def build_query_search(query_languages, bind_variables, filters=None, max_limit=
                 "phrase_field": "d.analyzed",
                 "analyzer": "pali_analyzer",
                 "bind_var": "@search_string_pa_fuzzy",
-            }
+            },
         ],
         "zh": [
             {

--- a/api/queries/text_view_queries.py
+++ b/api/queries/text_view_queries.py
@@ -8,6 +8,12 @@ FOR file IN files
     RETURN LENGTH(file.segment_pages)
 """
 
+QUERY_GET_MATCH_BY_ID = """
+FOR p IN parallels
+    FILTER p._key == @active_match_id
+    RETURN p
+"""
+
 
 QUERY_TEXT_AND_PARALLELS = """
 FOR file IN files

--- a/api/redis.conf
+++ b/api/redis.conf
@@ -1,0 +1,4 @@
+maxmemory 10gb
+maxmemory-policy allkeys-lru
+appendonly yes
+appendfsync everysec

--- a/api/search/search_utils.py
+++ b/api/search/search_utils.py
@@ -13,17 +13,15 @@ from aksharamukha import transliterate
 
 
 def preprocess_search_string(search_string, language):
-    result = {
-        "search_string_unprocessed": search_string
-    }
-    
+    result = {"search_string_unprocessed": search_string}
+
     search_string = _clean_search_string(search_string)
-    
+
     if language == "all":
         result.update(_process_all_languages(search_string))
     else:
         result.update(_process_single_language(search_string, language))
-    
+
     return result
 
 
@@ -47,13 +45,13 @@ def _process_single_language(search_string, language):
         result["pa"], result["pa_fuzzy"] = _process_pali(search_string)
     elif language == "zh":
         result["zh"] = _process_chinese(search_string)
-    
+
     return result
 
 
 def _process_all_languages(search_string):
     result = {}
-    
+
     if re.search("[\u0F00-\u0FDA]", search_string):
         result["bo"], result["bo_fuzzy"] = _process_tibetan(search_string)
         result["sa"] = result["bo"]
@@ -75,7 +73,7 @@ def _process_all_languages(search_string):
             result["pa"] = pa
             result["pa_fuzzy"] = pa_fuzzy
             result["bo"], result["bo_fuzzy"] = _process_tibetan(search_string)
-    
+
     return result
 
 
@@ -173,7 +171,7 @@ def _process_sanskrit(search_string):
         search_string = search_string.lower()
     except Exception:
         pass
-    
+
     try:
         sa_fuzzy = sanskrit_processor.process_batch(
             [search_string], mode="unsandhied", output_format="string"
@@ -188,30 +186,31 @@ def _process_tibetan(search_string):
     bo_wylie = search_string
     if re.search("[\u0F00-\u0FDA]", search_string):
         bo_wylie = bo_converter.toWylie(search_string)
-    
+
     try:
         bo_fuzzy = bn_analyzer.process_bo(bo_wylie)
     except Exception:
         bo_fuzzy = bo_wylie
-    
+
     return bo_wylie, bo_fuzzy
 
 
 def _process_pali(search_string):
     try:
-        search_string = transliterate.process('autodetect', 'IAST', search_string)
+        search_string = transliterate.process("autodetect", "IAST", search_string)
         search_string = search_string.lower()
     except Exception:
         pass
-    
+
     try:
         pa_fuzzy = sanskrit_processor.process_batch(
             [search_string], mode="unsandhied", output_format="string"
         )[0]
     except Exception:
         pa_fuzzy = ""
-    
+
     return search_string, pa_fuzzy if pa_fuzzy else search_string
+
 
 def _process_chinese(search_string):
     # For now, just return the cleaned string

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,12 +45,13 @@ services:
     restart: always
 
   redis:
-    image: redis:alpine
+    image: redis:latest
+    command: redis-server /usr/local/etc/redis/redis.conf
+    volumes:
+      - ./api/redis.conf:/usr/local/etc/redis/redis.conf
+      - redis_data:/data
     ports:
       - "6379:6379"
-    command: redis-server --save 60 1 --loglevel warning --appendonly yes
-    volumes:
-      - redis-data:/data
     networks:
       - app-network
     restart: always
@@ -129,7 +130,7 @@ volumes:
   dbdata:
   dharmanexus-data:
     external: true
-  redis-data:
+  redis_data:
 
 networks:
   app-network:


### PR DESCRIPTION
this does two things:
1. Add a active_match_id parameter to the text-parallels endpoint that overwrites filename, active_segments etc. (these are strictly speaking not needed when active_match_id is set). each FullMatchText object in the return now has an is_active_match flag that is true if the segment belongs to the active match and false if otherwise. For the frontend, this means in the third column you only need to supply the ID of the current match and then scroll to and highlight those segments that have the is_active_match flag set to true. This should simplify the text view third column handling significantly.
2. Fix some redis caching issues 